### PR TITLE
#43 Fix: jwt 만료 오류 해결

### DIFF
--- a/src/main/java/jpabasic/pinnolbe/controller/LoginController.java
+++ b/src/main/java/jpabasic/pinnolbe/controller/LoginController.java
@@ -24,11 +24,7 @@ public class LoginController {
         return "개힘들어";
     }
 
-//    @GetMapping("/logout")
-//    @Operation(summary="로그아웃")
-//    public ResponseEntity<?> logout(HttpServletResponse response) {
-//
-//    }
+//ㅡㅛ
 
 
 

--- a/src/main/java/jpabasic/pinnolbe/dto/login/oauth2/UserDto.java
+++ b/src/main/java/jpabasic/pinnolbe/dto/login/oauth2/UserDto.java
@@ -1,6 +1,7 @@
 package jpabasic.pinnolbe.dto.login.oauth2;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @Getter
@@ -11,4 +12,13 @@ public class UserDto {
     private String name;
     private String role;
     private String childName;
+
+    public UserDto(String username, String role) {
+        this.username = username;
+        this.role = role;
+    }
+
+    public UserDto() {
+
+    }
 }

--- a/src/main/java/jpabasic/pinnolbe/global/ApiErrorDetail.java
+++ b/src/main/java/jpabasic/pinnolbe/global/ApiErrorDetail.java
@@ -1,0 +1,30 @@
+package jpabasic.pinnolbe.global;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.ResponseEntity;
+
+
+@Data
+@Builder
+public class ApiErrorDetail {
+
+    private int status;
+    private String name;
+    private String code;
+    private String message;
+
+    public static ResponseEntity<ApiErrorDetail> toApiErrorDetail(ErrorCode e){
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(ApiErrorDetail.builder()
+                        .status(e.getHttpStatus().value())
+                        .name(e.name())
+                        .code(e.getCode())
+                        .message(e.getMessage())
+                        .build());
+    }
+
+
+
+}

--- a/src/main/java/jpabasic/pinnolbe/global/CustomExceptionHandler.java
+++ b/src/main/java/jpabasic/pinnolbe/global/CustomExceptionHandler.java
@@ -1,0 +1,15 @@
+package jpabasic.pinnolbe.global;
+
+import jpabasic.pinnolbe.global.exception.user.CustomException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ApiErrorDetail> handleCustomException(final CustomException e) {
+        return ApiErrorDetail.toApiErrorDetail(e.getErrorCode());
+    }
+}

--- a/src/main/java/jpabasic/pinnolbe/global/ErrorCode.java
+++ b/src/main/java/jpabasic/pinnolbe/global/ErrorCode.java
@@ -1,0 +1,20 @@
+package jpabasic.pinnolbe.global;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    NO_COOKIE(HttpStatus.UNAUTHORIZED,"TOKEN-001","REFRESH TOKEN 만료. 재로그인하세요."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,"TOKEN-002","ACCESS TOKEN이 만료되었습니다."),
+    REISSUE_TOKEN(HttpStatus.UNAUTHORIZED,"TOKEN-003","access token을 재발급 받으세요."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"TOKEN-004","refresh token이 만료되었습니다. 재로그인하세요.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/jpabasic/pinnolbe/global/ErrorDetailResponse.java
+++ b/src/main/java/jpabasic/pinnolbe/global/ErrorDetailResponse.java
@@ -1,0 +1,15 @@
+package jpabasic.pinnolbe.global;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+/*ExceptionHandlerFilter 상에서 사용하는 응답 구조*/
+public class ErrorDetailResponse {
+    private String msg;
+
+    @Builder
+    public ErrorDetailResponse(String msg) {
+        this.msg = msg;
+    }
+}

--- a/src/main/java/jpabasic/pinnolbe/global/ExceptionHandlerFilter.java
+++ b/src/main/java/jpabasic/pinnolbe/global/ExceptionHandlerFilter.java
@@ -1,0 +1,58 @@
+package jpabasic.pinnolbe.global;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jpabasic.pinnolbe.global.exception.user.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        try{
+            filterChain.doFilter(request, response);
+        }catch(CustomException e){
+            log.info("TokenException handler filter");
+            setErrorResponse(HttpStatus.UNAUTHORIZED,response,e);
+        }catch(RuntimeException e){
+            log.info("RuntimeException handler filter");
+            setErrorResponse(HttpStatus.FORBIDDEN,response,e);
+        }catch(Exception e){
+            log.info("Exception handler filter");
+            setErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR,response,e);
+        }
+    }
+
+    private void setErrorResponse(HttpStatus status,HttpServletResponse response,Exception e){
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String message=e.getMessage();
+        if(e instanceof CustomException customEx){
+            message=customEx.getErrorCode().getMessage();
+            status=customEx.getErrorCode().getHttpStatus();
+            response.setStatus(status.value());
+        }
+
+        String body = String.format("{\"code\": %d, \"message\": \"%s\"}", status.value(), message);
+        try{
+            response.getWriter().write(body);
+        }catch(IOException ioException){
+            log.error("failed to write error response",ioException);
+        }
+    }
+}

--- a/src/main/java/jpabasic/pinnolbe/global/exception/user/CustomException.java
+++ b/src/main/java/jpabasic/pinnolbe/global/exception/user/CustomException.java
@@ -1,0 +1,11 @@
+package jpabasic.pinnolbe.global.exception.user;
+
+import jpabasic.pinnolbe.global.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    ErrorCode errorCode;
+}

--- a/src/main/java/jpabasic/pinnolbe/jwt/JwtFilter.java
+++ b/src/main/java/jpabasic/pinnolbe/jwt/JwtFilter.java
@@ -10,8 +10,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import jpabasic.pinnolbe.domain.RefreshToken;
 import jpabasic.pinnolbe.dto.login.oauth2.CustomOAuth2User;
 import jpabasic.pinnolbe.dto.login.oauth2.UserDto;
+import jpabasic.pinnolbe.global.ErrorCode;
+import jpabasic.pinnolbe.global.exception.user.CustomException;
 import jpabasic.pinnolbe.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -21,18 +24,19 @@ import java.io.IOException;
 import java.util.Optional;
 
 @RequiredArgsConstructor
+@Slf4j
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenService tokenService;
 
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String requestUri = request.getRequestURI();
-        String accessToken = null;
-        String refreshToken = null;
+//        String accessToken = null;
+//        String refreshToken = null;
 
         // health-check bypass
         if (requestUri.equals("/health-check")) {
@@ -42,103 +46,94 @@ public class JwtFilter extends OncePerRequestFilter {
 
 
         //Cookie들을 불러온 뒤 Authorization key에 담긴 쿠키를 찾음
-        Cookie[] cookies = request.getCookies();
-
-        if (cookies == null) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("Authorization")) {
-                accessToken = cookie.getValue();
-            } else if (cookie.getName().equals("RefreshToken")) {
-                refreshToken = cookie.getValue();
-            }
-        }
-
-
-        //Authorization 헤더 검증
-        if (accessToken == null) {
-            System.out.println("Authorization 쿠키 없음.. token null");
-            filterChain.doFilter(request, response);
-
-            //조건이 해당되면 메서드 종료(필수)
-            return;
-        }
-
+//        Cookie[] cookies = request.getCookies();
+//
+//        if (cookies == null) {
+//            filterChain.doFilter(request, response);
+//            return;
+//        }
+//
+//        for (Cookie cookie : cookies) {
+//            if (cookie.getName().equals("Authorization")) {
+//                accessToken = cookie.getValue();
+//            } else if (cookie.getName().equals("RefreshToken")) {
+//                refreshToken = cookie.getValue();
+//            }
+//        }
+        String accessToken=getTokenFromCookies(request,"Authorization");
+        String refreshToken=getTokenFromCookies(request,"RefreshToken");
 
         try {
-
-            //accessToken이 만료되었는지 먼저 검사
-            if (jwtUtil.isExpired(accessToken)) {
-                throw new ExpiredJwtException(null, null, "AccessToken 만료됨");
-            }
-
+            //Authorization 헤더 검증
+            validateTokens(accessToken, refreshToken);
             authenticateWithToken(accessToken);
-            filterChain.doFilter(request, response);
-            return;
 
-        } catch (ExpiredJwtException e) {
-            System.out.println("🚨파싱 도중 access token expired");
+        } catch (CustomException e) {
+            ErrorCode errorCode = e.getErrorCode();
 
-            //Refresh Token 검사
-            if (refreshToken != null && !jwtUtil.isExpired(refreshToken)) {
-                //토큰에서 username, role 획득
-                String username = jwtUtil.getUsername(refreshToken);
-                String role = jwtUtil.getRole(refreshToken);
+            if (errorCode == ErrorCode.REISSUE_TOKEN) {
+                try {
+                    String newAccessToken = tokenService.reissueAccessToken(refreshToken, response);
+                    log.info("🍪 access token 재발급 완료");
 
-                //Refresh Token DB에 저장된 것과 비교
-                Optional<RefreshToken> entity = refreshTokenRepository.
-                        findByUsername(username);
-                String savedRefreshToken=entity.get().getToken();
-
-                if (savedRefreshToken != null && savedRefreshToken.equals(refreshToken)) {
-                    //새 Access Token 생성
-                    String newAccessToken = jwtUtil.createJwt(username, role, 5 * 60 * 1000L); //access token 5분
-                    response.addCookie(createCookie("Authorization", newAccessToken, 30 * 60)); //쿠키 5분
-
-                    //인증된 사용자로 등록
                     authenticateWithToken(newAccessToken);
-
-                    System.out.println("✅ Access Token 재발급 성공");
-                } else {
-                    System.out.println("😡 Refresh Token 없음 or 만료"); ///Refresh Token 만료되면 어떡하죠?
-                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                    log.info("🍪 access token 유저 정보 저장 완료");
+                } catch (CustomException reissueEx) {
                     return;
                 }
+            } else {
+                return;
             }
-        }
 
+        }
         filterChain.doFilter(request, response);
     }
 
 
     private void authenticateWithToken(String accessToken) {
-        String username=jwtUtil.getUsername(accessToken);
-        String role=jwtUtil.getRole(accessToken);
+        String username = jwtUtil.getUsername(accessToken);
+        String role = jwtUtil.getRole(accessToken);
 
         //userDto를 생성하여 값 set
-        UserDto userDto=new UserDto();
-        userDto.setUsername(username);
-        userDto.setRole(role);
+        UserDto userDto = new UserDto(username,role);
 
         //UserDetails(OAuth2User)에 회원 정보 객체 담기
-        CustomOAuth2User customOAuth2User=new CustomOAuth2User(userDto);
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(userDto);
 
         //스프링 시큐리티 인증 토큰 생성
-        Authentication authToken=new UsernamePasswordAuthenticationToken(customOAuth2User,null,customOAuth2User.getAuthorities());
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
         //세션에 사용자 등록 //SecurityContext에 인증 정보 등록->이후 컨트롤러나 @AuthenticationPrincipal 에서 접근 가능
         SecurityContextHolder.getContext().setAuthentication(authToken);
     }
 
 
-    private Cookie createCookie(String key, String value, int maxAgeSeconds) {
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(maxAgeSeconds);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        return cookie;
+
+    public void validateTokens(String accessToken, String refreshToken) {
+
+        if (accessToken == null && refreshToken == null) {
+            throw new CustomException(ErrorCode.NO_COOKIE);
+        }
+
+        if (accessToken == null) {
+            throw new CustomException(ErrorCode.REISSUE_TOKEN);
+        }
+
+        if (jwtUtil.isExpired(accessToken)){
+            throw new CustomException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+        }
+
     }
+
+
+    private String getTokenFromCookies(HttpServletRequest request,String name) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals(name)) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+
 }

--- a/src/main/java/jpabasic/pinnolbe/jwt/JwtUtil.java
+++ b/src/main/java/jpabasic/pinnolbe/jwt/JwtUtil.java
@@ -1,7 +1,13 @@
 package jpabasic.pinnolbe.jwt;
 
 
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import jpabasic.pinnolbe.domain.RefreshToken;
+import jpabasic.pinnolbe.global.ErrorCode;
+import jpabasic.pinnolbe.global.exception.user.CustomException;
+import jpabasic.pinnolbe.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -9,6 +15,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.Optional;
 
 @Component
 public class JwtUtil {
@@ -18,20 +25,31 @@ public class JwtUtil {
     public JwtUtil(@Value("${jwt.secret}") String secret) {
         System.out.println("✅✅✅secret" + secret);
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
-
     }
 
 
     public String getUsername(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+        try {
+            return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+        }
     }
 
     public String getRole(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+        try {
+            return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+        }
     }
 
     public Boolean isExpired(String token) {
-        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+        try {
+            return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(ErrorCode.EXPIRED_ACCESS_TOKEN);
+        }
     }
 
 
@@ -45,5 +63,6 @@ public class JwtUtil {
                 .signWith(secretKey)
                 .compact();
     }
+
 
 }

--- a/src/main/java/jpabasic/pinnolbe/jwt/TokenService.java
+++ b/src/main/java/jpabasic/pinnolbe/jwt/TokenService.java
@@ -1,0 +1,47 @@
+package jpabasic.pinnolbe.jwt;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jpabasic.pinnolbe.domain.RefreshToken;
+import jpabasic.pinnolbe.global.ErrorCode;
+import jpabasic.pinnolbe.global.exception.user.CustomException;
+import jpabasic.pinnolbe.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public String reissueAccessToken(String refreshToken, HttpServletResponse response) {
+        if (jwtUtil.isExpired(refreshToken)) {
+            throw new CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
+
+        String username = jwtUtil.getUsername(refreshToken);
+        String role = jwtUtil.getRole(refreshToken);
+
+        RefreshToken savedToken = refreshTokenRepository.findByUsername(username)
+                .orElseThrow(() -> new CustomException(ErrorCode.NO_COOKIE));
+
+        if (!savedToken.getToken().equals(refreshToken)) {
+            throw new CustomException(ErrorCode.NO_COOKIE);
+        }
+
+        String newAccessToken = jwtUtil.createJwt(username, role, 5 * 60 * 1000L);
+        response.addCookie(createCookie("Authorization", newAccessToken, 5 * 60));
+        return newAccessToken;
+    }
+
+    private Cookie createCookie(String key, String value, int maxAgeSeconds) {
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(maxAgeSeconds);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        return cookie;
+    }
+}

--- a/src/main/java/jpabasic/pinnolbe/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/jpabasic/pinnolbe/oauth2/CustomSuccessHandler.java
@@ -91,7 +91,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         //첫 로그인 -> 자녀 정보 받기, n번째 로그인 -> 자녀 정보 안받아도됨
         boolean isFirstLogin = customUserDetails.isFirstLogin();
-        String targetUrl = isFirstLogin ? localUrl + "/childInfo" : localUrl + "/main";
+        String targetUrl = isFirstLogin ? deployUrl + "/childInfo" : deployUrl + "/main";
 
         response.sendRedirect(targetUrl);
 
@@ -101,7 +101,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(maxAgeSeconds);
-        //cookie.setSecure(true); //https 환경에서만 쿠키 전송
+        cookie.setSecure(true); //https 환경에서만 쿠키 전송
         cookie.setPath("/"); //모든 위치(전역)에서 쿠키를 볼 수 있음
         cookie.setHttpOnly(true); //JavaScript가 쿠키를 가져갈 수 없도록
 


### PR DESCRIPTION
---
title: #43 Fix: jwt 만료 오류 해결
---


### ✨ 관련된 이슈
- close #43 #45

### 🙌 작업 내용
- global error handler 적용
- refresh token 검사 후 access token 재발급 로직 구현
1. access token+cookie (5분) & refresh token+cookie(2주) 발급
2. access token 만료 시(access token cookie가 없을때), 필터 단 error handling -> refresh token을 통해 access token 재발급
3. access token, refresh token 모두 만료(어떤 쿠키도 전달받지 못할 때 ) -> 재로그인


