### PR TITLE
fix: 유저 정보 안불러와져도 로그인 처리 되는 오류 해결

### DIFF
--- a/src/main/java/jpabasic/pinnolbe/jwt/JwtFilter.java
+++ b/src/main/java/jpabasic/pinnolbe/jwt/JwtFilter.java
@@ -54,53 +54,32 @@ public class JwtFilter extends OncePerRequestFilter {
         }
 
 
-
-
-
-        //Cookie들을 불러온 뒤 Authorization key에 담긴 쿠키를 찾음
-//        Cookie[] cookies = request.getCookies();
-//
-//        if (cookies == null) {
-//            filterChain.doFilter(request, response);
-//            return;
-//        }
-//
-//        for (Cookie cookie : cookies) {
-//            if (cookie.getName().equals("Authorization")) {
-//                accessToken = cookie.getValue();
-//            } else if (cookie.getName().equals("RefreshToken")) {
-//                refreshToken = cookie.getValue();
-//            }
-//        }
         String accessToken=getTokenFromCookies(request,"Authorization");
         String refreshToken=getTokenFromCookies(request,"RefreshToken");
 
-        try {
-            //Authorization 헤더 검증
-//            validateTokens(accessToken, refreshToken);
-            System.out.println("✅ validaToken 완료");
-            authenticateWithToken(accessToken);
-
-        } catch (CustomException e) {
-            ErrorCode errorCode = e.getErrorCode();
-
-            if (errorCode == ErrorCode.REISSUE_TOKEN) {
-                try {
-                    String newAccessToken = tokenService.reissueAccessToken(refreshToken, response);
-                    log.info("🍪 access token 재발급 완료");
-
-                    authenticateWithToken(newAccessToken);
-                    log.info("🍪 access token 유저 정보 저장 완료");
-                } catch (CustomException reissueEx) {
-                    return;
-                }
-            } else {
+        try{
+            if(accessToken!=null && !jwtUtil.isExpired(accessToken)){
+                //access token 정상
+                authenticateWithToken(accessToken);
+                log.info("😎 access token 유효 -> security context 저장 완료");
+            }else if(refreshToken!=null && !jwtUtil.isExpired(refreshToken)){
+                //access token 만료 -> refresh token으로 새로 발급
+                String newAccessToken=tokenService.reissueAccessToken(refreshToken,response);
+                authenticateWithToken(newAccessToken);
+                log.info("😎 access token 재발급 및 securityContext 저장 완료");
+            }else {
+                // Refresh Token도 없거나 만료 → 쿠키 삭제 후 재로그인 유도
+                clearAuthCookies(response);
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh token expired. Please login again.");
                 return;
             }
-
+            }catch(CustomException e){
+                log.warn("인증 실패:{}",e.getErrorCode());
+                return;
+            }
+        filterChain.doFilter(request,response);
         }
-        filterChain.doFilter(request, response);
-    }
+
 
 
     private void authenticateWithToken(String accessToken) {
@@ -118,6 +97,20 @@ public class JwtFilter extends OncePerRequestFilter {
         //세션에 사용자 등록 //SecurityContext에 인증 정보 등록->이후 컨트롤러나 @AuthenticationPrincipal 에서 접근 가능
         SecurityContextHolder.getContext().setAuthentication(authToken);
     }
+
+    private void clearAuthCookies(HttpServletResponse response) {
+        Cookie expiredAuth = new Cookie("Authorization", null);
+        expiredAuth.setPath("/");
+        expiredAuth.setMaxAge(0);
+
+        Cookie expiredRefresh = new Cookie("RefreshToken", null);
+        expiredRefresh.setPath("/");
+        expiredRefresh.setMaxAge(0);
+
+        response.addCookie(expiredAuth);
+        response.addCookie(expiredRefresh);
+    }
+
 
 
 

--- a/src/main/java/jpabasic/pinnolbe/jwt/JwtFilter.java
+++ b/src/main/java/jpabasic/pinnolbe/jwt/JwtFilter.java
@@ -61,12 +61,12 @@ public class JwtFilter extends OncePerRequestFilter {
             if(accessToken!=null && !jwtUtil.isExpired(accessToken)){
                 //access token 정상
                 authenticateWithToken(accessToken);
-                log.info("😎 access token 유효 -> security context 저장 완료");
+//                log.info("😎 access token 유효 -> security context 저장 완료");
             }else if(refreshToken!=null && !jwtUtil.isExpired(refreshToken)){
                 //access token 만료 -> refresh token으로 새로 발급
                 String newAccessToken=tokenService.reissueAccessToken(refreshToken,response);
                 authenticateWithToken(newAccessToken);
-                log.info("😎 access token 재발급 및 securityContext 저장 완료");
+//                log.info("😎 access token 재발급 및 securityContext 저장 완료");
             }else {
                 // Refresh Token도 없거나 만료 → 쿠키 삭제 후 재로그인 유도
                 clearAuthCookies(response);

--- a/src/main/java/jpabasic/pinnolbe/jwt/JwtUtil.java
+++ b/src/main/java/jpabasic/pinnolbe/jwt/JwtUtil.java
@@ -22,7 +22,7 @@ public class JwtUtil {
     private final SecretKey secretKey;
 
     public JwtUtil(@Value("${jwt.secret}") String secret) {
-        System.out.println("✅✅✅secret" + secret);
+//        System.out.println("✅✅✅secret" + secret);
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
@@ -45,14 +45,14 @@ public class JwtUtil {
 
     public Boolean isExpired(String token) {
         try {
-            System.out.println("🖥️ isExpired 확인 시도");
+//            System.out.println("🖥️ isExpired 확인 시도");
             JwtParser parser = Jwts.parser().verifyWith(secretKey).build();
             Jws<Claims> claimsJws = parser.parseSignedClaims(token);
             Date exp = claimsJws.getPayload().getExpiration();
-            System.out.println("🖥️ exp: " + exp);
+//            System.out.println("🖥️ exp: " + exp);
             return exp.before(new Date());
         } catch (ExpiredJwtException e) {
-            System.out.println("🖥️ expiredDate (catch): " + e.getClaims().getExpiration());
+//            System.out.println("🖥️ expiredDate (catch): " + e.getClaims().getExpiration());
             return true;
         } catch(Exception e){
             return true;

--- a/src/main/java/jpabasic/pinnolbe/jwt/TokenService.java
+++ b/src/main/java/jpabasic/pinnolbe/jwt/TokenService.java
@@ -8,6 +8,7 @@ import jpabasic.pinnolbe.global.exception.user.CustomException;
 import jpabasic.pinnolbe.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,13 +17,17 @@ public class TokenService {
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
+
+    @Transactional
     public String reissueAccessToken(String refreshToken, HttpServletResponse response) {
         if (jwtUtil.isExpired(refreshToken)) {
             throw new CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN);
         }
 
         String username = jwtUtil.getUsername(refreshToken);
+        System.out.println("😎username: " + username);
         String role = jwtUtil.getRole(refreshToken);
+        System.out.println("😎role: " + role);
 
         RefreshToken savedToken = refreshTokenRepository.findByUsername(username)
                 .orElseThrow(() -> new CustomException(ErrorCode.NO_COOKIE));
@@ -31,10 +36,11 @@ public class TokenService {
             throw new CustomException(ErrorCode.NO_COOKIE);
         }
 
-        String newAccessToken = jwtUtil.createJwt(username, role, 5 * 60 * 1000L);
+        String newAccessToken = jwtUtil.createJwt(username, role, 1 * 60 * 1000L);
         response.addCookie(createCookie("Authorization", newAccessToken, 5 * 60));
         return newAccessToken;
     }
+
 
     private Cookie createCookie(String key, String value, int maxAgeSeconds) {
         Cookie cookie = new Cookie(key, value);

--- a/src/main/java/jpabasic/pinnolbe/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/jpabasic/pinnolbe/oauth2/CustomSuccessHandler.java
@@ -56,7 +56,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 
         //Access Token 생성 : 5분
-        String accessToken = jwtUtil.createJwt(username, role, 1 * 60 * 1000L);
+        String accessToken = jwtUtil.createJwt(username, role, 5 * 60 * 1000L);
 
         //refresh token 재사용 or 생성
         String refreshToken = "";
@@ -80,7 +80,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         //토큰은 쿠키 방식으로 프론트 측에 전달 -> 리다이렉트
         //access Token
-        response.addCookie(createCookie("Authorization", accessToken, 5 * 60));//5분
+        response.addCookie(createCookie("Authorization", accessToken, 10 * 60));//10분
 
         //refresh Token
         response.addCookie(createCookie("RefreshToken", refreshToken, 14 * 24 * 60 * 60));//14일

--- a/src/main/java/jpabasic/pinnolbe/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/jpabasic/pinnolbe/oauth2/CustomSuccessHandler.java
@@ -56,7 +56,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
 
         //Access Token 생성 : 5분
-        String accessToken = jwtUtil.createJwt(username, role, 5 * 60 * 1000L);
+        String accessToken = jwtUtil.createJwt(username, role, 1 * 60 * 1000L);
 
         //refresh token 재사용 or 생성
         String refreshToken = "";
@@ -65,7 +65,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             String existingToken = token.get().getToken();
             System.out.println("🖥️ existingToken: " + existingToken);
 
-            if (jwtUtil.isExpired(existingToken)) {
+            if (!jwtUtil.isExpired(existingToken)) {
                 // jwtUtil.isExpired=true인 경우 실행됨
                 refreshToken = existingToken;
                 userService.saveExistingRefreshToken(username, refreshToken);
@@ -80,7 +80,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         //토큰은 쿠키 방식으로 프론트 측에 전달 -> 리다이렉트
         //access Token
-        response.addCookie(createCookie("Authorization", accessToken, 10 * 60));//5분
+        response.addCookie(createCookie("Authorization", accessToken, 5 * 60));//5분
 
         //refresh Token
         response.addCookie(createCookie("RefreshToken", refreshToken, 14 * 24 * 60 * 60));//14일

--- a/src/main/java/jpabasic/pinnolbe/service/login/CustomOAuth2UserService.java
+++ b/src/main/java/jpabasic/pinnolbe/service/login/CustomOAuth2UserService.java
@@ -30,10 +30,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
         OAuth2User oAuth2User = super.loadUser(userRequest); //생성자를 부름 -> 유저 정보 가져옴
-        System.out.println("✏️✏️" + oAuth2User);
+//        System.out.println("✏️✏️" + oAuth2User);
 
         OAuth2Response oAuth2Response = new KakaoResponse(oAuth2User.getAttributes());
-        System.out.println("✅" + oAuth2Response);
+//        System.out.println("✅" + oAuth2Response);
 
         //OAuth2User를 SecurityConfig에 등록해야 사용할 수 있음
 
@@ -63,7 +63,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             userDto.setChildName(null);
 
 
-            System.out.println("✅ 새로운 유저" + userDto);
+//            System.out.println("✅ 새로운 유저" + userDto);
             return new CustomOAuth2User(userDto);
 
         } else { //로그인
@@ -81,7 +81,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             userDto.setChildName(existData.getChildName());
 
-            System.out.println("✅유저" + userDto);
+//            System.out.println("✅유저" + userDto);
             return new CustomOAuth2User(userDto);
 
 

--- a/src/main/java/jpabasic/pinnolbe/service/login/UserService.java
+++ b/src/main/java/jpabasic/pinnolbe/service/login/UserService.java
@@ -40,7 +40,7 @@ public class UserService {
         String username=oAuth2User.getUsername(); //인증 정보 꺼냄
         User user=userRepository.findByUsername(username); //DB에서 최신 정보 조회
 
-        System.out.println("🔍 Principal 클래스: " + auth.getPrincipal().getClass().getName());
+//        System.out.println("🔍 Principal 클래스: " + auth.getPrincipal().getClass().getName());
 
 
         return user;

--- a/src/main/java/jpabasic/pinnolbe/service/login/UserService.java
+++ b/src/main/java/jpabasic/pinnolbe/service/login/UserService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -30,6 +31,7 @@ public class UserService {
 
 
     //로그인 된 상태에서 유저 정보 가져오기
+    @Transactional
     public User getUserInfo(){
 
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
@@ -45,6 +47,7 @@ public class UserService {
     }
 
     //첫 로그인 시 자녀 정보 입력하기
+    @Transactional
     public void inputUserInfo(User user, ChildInfoDto dto){
 
         if(user==null){
@@ -68,6 +71,7 @@ public class UserService {
 
 
     //유저 정보 받아오기
+    @Transactional
     public UserInfoDto getUserInfoDto(User user){
         String userId=user.getId();
 //        Reward reward=rewardRepository.findByUserId(userId);
@@ -84,11 +88,13 @@ public class UserService {
 
 
     //refresh Token 관련
+    @Transactional
     public void deleteExpiredRefreshToken(RefreshToken refreshToken){
         refreshTokenRepository.delete(refreshToken);
         log.info("✅ 만료된 refresh token 삭제");
     }
-    
+
+    @Transactional
     public void saveNewRefreshToken(String username,String refreshToken){
         User user=userRepository.findByUsername(username);
         user.setRefreshToken(refreshToken);
@@ -100,6 +106,7 @@ public class UserService {
         log.info("✅ user RefreshToken 생성 후 저장 완료");
     }
 
+    @Transactional
     public void saveExistingRefreshToken(String username,String refreshToken){
         User user=userRepository.findByUsername(username);
         user.setRefreshToken(refreshToken);


### PR DESCRIPTION

### 🙌 작업 내용
- 기존의 문제 : SecurityContext에 유저 정보가 안 불러와지는 채로 로그인이 되었다고 프론트 측에 전달되는 문제 -> /login 으로 리다이렉트 되지 않고, 실제로는 로그인되지 않은 상태에서 /main으로 리다이렉트. 
- 해결 방법 : 토큰을 검증하는 여러 로직 중 validateTokens 제거. 기존에 CustomException의 ErrorCode에 따라 토큰 재발급 로직을 짰는데, 이 customException이 제대로 처리가 되지 않아서 ErrorCode에 따라 분기점을 처리 하지 않고, 직접 accessToken OR refreshToken이 없는 경우, 만료된 경우를 일일히 분기 처리하여 재발급 로직을 재설계함. 

- RefreshToken 이슈 : refreshToken이 만료된 경우에도 /login으로 리다이렉트 되지않고, /main으로 가는 이슈 발생(마찬가지로 401 에러가 아닌, CustomException 처리 때문에 예외 catch를 제대로 하지 못한 이유) -> clearAuthCookie 메소드를 추가하여 refreshToken 쿠키를 삭제 및 초기화하여 401 에러를 터뜨리고 그걸 프론트가 받아서 /login으로 리다이렉트 될 수 있도록 함. 
