### PR TITLE
Fix: 학습하기 COMPLETED & EXIT 로직 재설계

### DIFF
--- a/src/main/java/jpabasic/pinnolbe/controller/SesController.java
+++ b/src/main/java/jpabasic/pinnolbe/controller/SesController.java
@@ -13,15 +13,15 @@ public class SesController {
 
     private final SseService sseService;
 
-    @GetMapping("/subscribe/{id}")
-    public SseEmitter subscribe(@PathVariable String id) {
-        return sseService.subscribe(id);
-    }
-
-    @PostMapping("/send/{id}")
-    public void sendAlarm(@PathVariable String id, @RequestBody SseSendRequest request) {
-        sseService.sendToClient(id,request.eventName(),request.data());
-    }
+//    @GetMapping("/subscribe/{id}")
+//    public SseEmitter subscribe(@PathVariable String id) {
+//        return sseService.subscribe(id);
+//    }
+//
+//    @PostMapping("/send/{id}")
+//    public void sendAlarm(@PathVariable String id, @RequestBody SseSendRequest request) {
+//        sseService.sendToClient(id,request.eventName(),request.data());
+//    }
 
 
 }

--- a/src/main/java/jpabasic/pinnolbe/controller/analysis/StudyLogController.java
+++ b/src/main/java/jpabasic/pinnolbe/controller/analysis/StudyLogController.java
@@ -53,8 +53,8 @@ public class StudyLogController {
     @Operation(summary="현재 단원 레벨")
     public ApiResponse<NowStudyingLevelDto> getNowStudyingLevel() {
         User user = userService.getUserInfo();
-        String sessionLogId=user.getStudySessionLogId();
-        NowStudyingLevelDto result=studyLogService.getNowStudyingLevel(user,sessionLogId);
+
+        NowStudyingLevelDto result=studyLogService.getNowStudyingLevel(user);
         return ApiResponse.success("현재 학습중인 단원과 레벨입니다.",result);
     }
 

--- a/src/main/java/jpabasic/pinnolbe/controller/study/QuestionController.java
+++ b/src/main/java/jpabasic/pinnolbe/controller/study/QuestionController.java
@@ -1,26 +1,18 @@
-package jpabasic.pinnolbe.controller;
+package jpabasic.pinnolbe.controller.study;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jpabasic.pinnolbe.domain.User;
-import jpabasic.pinnolbe.domain.question.QueCollection;
 import jpabasic.pinnolbe.dto.question.*;
 import jpabasic.pinnolbe.global.ApiResponse;
 import jpabasic.pinnolbe.service.question.QuestionService;
 import jpabasic.pinnolbe.service.question.SseService;
 import jpabasic.pinnolbe.service.study.StudyLogService;
 import jpabasic.pinnolbe.service.login.UserService;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @RestController
 @RequestMapping("/api/question")

--- a/src/main/java/jpabasic/pinnolbe/controller/study/QuizController.java
+++ b/src/main/java/jpabasic/pinnolbe/controller/study/QuizController.java
@@ -1,4 +1,4 @@
-package jpabasic.pinnolbe.controller;
+package jpabasic.pinnolbe.controller.study;
 
 import jpabasic.pinnolbe.domain.study.Quiz;
 import jpabasic.pinnolbe.service.analyze.QuizService;

--- a/src/main/java/jpabasic/pinnolbe/controller/study/StudyController.java
+++ b/src/main/java/jpabasic/pinnolbe/controller/study/StudyController.java
@@ -1,15 +1,10 @@
-package jpabasic.pinnolbe.controller;
+package jpabasic.pinnolbe.controller.study;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import jpabasic.pinnolbe.domain.User;
-import jpabasic.pinnolbe.domain.study.Study;
 import jpabasic.pinnolbe.dto.question.QuestionResponse;
-import jpabasic.pinnolbe.dto.study.ChapterDto;
-import jpabasic.pinnolbe.dto.study.ChaptersDto;
 import jpabasic.pinnolbe.dto.study.book.BookListResponseDto;
 import jpabasic.pinnolbe.dto.study.chapter.ChapterListResponseDto;
 import jpabasic.pinnolbe.dto.study.feedback.FeedBackRequestDto;
@@ -24,9 +19,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/study")

--- a/src/main/java/jpabasic/pinnolbe/controller/study/StudySessionController.java
+++ b/src/main/java/jpabasic/pinnolbe/controller/study/StudySessionController.java
@@ -1,10 +1,9 @@
-package jpabasic.pinnolbe.controller;
+package jpabasic.pinnolbe.controller.study;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jpabasic.pinnolbe.domain.User;
 import jpabasic.pinnolbe.dto.analyze.StudySessionLogResponseDto;
 import jpabasic.pinnolbe.dto.analyze.StudySessionSummaryDto;
-import jpabasic.pinnolbe.dto.study.ChapterDto;
 import jpabasic.pinnolbe.global.ApiResponse;
 import jpabasic.pinnolbe.service.analyze.WeeklyAnalysisService;
 import jpabasic.pinnolbe.service.study.StudyService;
@@ -37,11 +36,12 @@ public class StudySessionController {
                         """)
     public ApiResponse<Map<String,Object>> startLevel(
             @RequestParam int level,
+            @RequestParam String bookId,
             @RequestParam String chapterId){
 
         User user=userService.getUserInfo();
         //학습 상태 저장할 Redis(세부 학습내용), studysessionLog(현 학습 상황) 생성 및 확인
-        String studySessionLogId=studySessionService.startLevel(user,level,chapterId);
+        String studySessionLogId=studySessionService.startLevel(user,level,chapterId,bookId);
         //학습할 내용 가져오기
         Map<String,Object> levelContents=studyService.getChapterContents(chapterId,level);
         levelContents.put("studySessionLogId",studySessionLogId);
@@ -58,6 +58,7 @@ public class StudySessionController {
     ✅ 상태별 전송 규칙:
     - **ACTIVE ↔ INACTIVE** 전환 시 → `startTime`은 무시하고 `lastActive`만 전송
     - **COMPLETED** (학습 완료 시) → `startTime` / `lastActive` 모두 무시 가능
+    - **EXIT** : 학습 중간에 창을 아예 나갔을 때
     
     ✅ 6단계까지 해당 chapter 학습 완료 시:
     - isCompleted=true
@@ -93,10 +94,5 @@ public class StudySessionController {
         }
 
     }
-
-
-
-
-
 
 }

--- a/src/main/java/jpabasic/pinnolbe/domain/Status.java
+++ b/src/main/java/jpabasic/pinnolbe/domain/Status.java
@@ -5,5 +5,5 @@ public enum Status {
     ACTIVE, //학습 중
     INACTIVE, //이벤트 인식 안됨
     COMPLETED, //학습 완료
-    EXITED //강제 종료 (timeout)
+    EXIT //강제 종료 (timeout-TTL 만료 시 ) & 유저가 학습하기 창에서 나갔을 때
 }

--- a/src/main/java/jpabasic/pinnolbe/domain/analyze/StudySessionLog.java
+++ b/src/main/java/jpabasic/pinnolbe/domain/analyze/StudySessionLog.java
@@ -29,10 +29,11 @@ public class StudySessionLog extends BaseEntity {
     private Status status;
 
     public StudySessionLog(
-            String userId,String chapterId,int level
+            String userId,String chapterId,String bookId,int level
     ) {
         this.userId=userId;
         this.chapterId=chapterId;
+        this.bookId=bookId;
         this.level=level;
         this.totalDuration=0;
         this.timeZoneDurations=new HashMap<>();

--- a/src/main/java/jpabasic/pinnolbe/domain/study/Book.java
+++ b/src/main/java/jpabasic/pinnolbe/domain/study/Book.java
@@ -13,8 +13,8 @@ import java.util.List;
 public class Book {
 
     @Id
-    private ObjectId id;
-//    private int bookId;
+    private String id;
+    private int bookLevel;
     private String title;
 //    private Long chapter_id;
 

--- a/src/main/java/jpabasic/pinnolbe/dto/analyze/StudySessionLogResponseDto.java
+++ b/src/main/java/jpabasic/pinnolbe/dto/analyze/StudySessionLogResponseDto.java
@@ -1,5 +1,6 @@
 package jpabasic.pinnolbe.dto.analyze;
 
+import jpabasic.pinnolbe.domain.Status;
 import jpabasic.pinnolbe.domain.analyze.StudySessionLog;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/jpabasic/pinnolbe/dto/analyze/StudySessionSummaryDto.java
+++ b/src/main/java/jpabasic/pinnolbe/dto/analyze/StudySessionSummaryDto.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 public class StudySessionSummaryDto {
 
     private String userId;
+    private String bookId;
     private String chapterId;
     @Schema(description = "현재 학습 하고 있는 level")
     private int level;

--- a/src/main/java/jpabasic/pinnolbe/dto/study/chapter/ChapterListResponseDto.java
+++ b/src/main/java/jpabasic/pinnolbe/dto/study/chapter/ChapterListResponseDto.java
@@ -21,6 +21,7 @@ public class ChapterListResponseDto {
 
     private String sessionLogId;
     private String currentChapterId;
+    private Integer currentLevel; //이어서 학습할 단계
     private Slice<ChapterResponseDto> chapterList; //chapterId,chapterTitle
 
 

--- a/src/main/java/jpabasic/pinnolbe/dto/study/feedback/NowStudyingLevelDto.java
+++ b/src/main/java/jpabasic/pinnolbe/dto/study/feedback/NowStudyingLevelDto.java
@@ -9,7 +9,11 @@ import lombok.Setter;
 @AllArgsConstructor
 public class NowStudyingLevelDto {
 
+    private int bookLevel;
+    private String bookTitle;
+    private String chapterId;
     private String chapterTitle;
     private int currentLevel;
+
 
 }

--- a/src/main/java/jpabasic/pinnolbe/global/ErrorCode.java
+++ b/src/main/java/jpabasic/pinnolbe/global/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND,"session-001","기존의 study session 기록이 없어요."),
     STUDY_SESSION_LOG_NOT_FOUND(HttpStatus.NOT_FOUND,"session-002","StudySessionLog 엔티티가 없어요."),
     SESSION_LOG_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"session-003","세션 로그 삭제에 오류가 발생했어요."),
+    STUDY_SESSION_ID_NOT_FOUND(HttpStatus.NOT_FOUND,"session-004","user필드에 저장되어있던 sessionId로 찾아봤지만 해당 세션을 DB에서 찾을 수 없어요."),
 
     //chapter 관련
     CHAPTER_NOT_FOUND(HttpStatus.NOT_FOUND,"chapter-001","해당 chapter내용을 찾을 수 없어요."),

--- a/src/main/java/jpabasic/pinnolbe/scheduler/SessionTTLScheduler.java
+++ b/src/main/java/jpabasic/pinnolbe/scheduler/SessionTTLScheduler.java
@@ -31,7 +31,7 @@ public class SessionTTLScheduler {
                 StudySession session = redisTemplate.opsForValue().get(key);
                 if (session == null) continue;
 
-                session.setStatus(Status.EXITED);
+                session.setStatus(Status.EXIT);
                 studySessionService.saveToDatabase(session);
                 redisTemplate.delete(key);
                 log.info("[TTL] TTL 만료 세션 정리: {} (남은 TTL={}초)", key, ttl);

--- a/src/main/java/jpabasic/pinnolbe/service/study/StudyLogService.java
+++ b/src/main/java/jpabasic/pinnolbe/service/study/StudyLogService.java
@@ -1,9 +1,11 @@
 package jpabasic.pinnolbe.service.study;
 
+import jpabasic.pinnolbe.domain.Status;
 import jpabasic.pinnolbe.domain.analyze.StudyLog;
 import jpabasic.pinnolbe.domain.analyze.StudySessionLog;
 import jpabasic.pinnolbe.domain.analyze.WeeklyAnalysis;
 import jpabasic.pinnolbe.domain.question.QueCollection;
+import jpabasic.pinnolbe.domain.study.Book;
 import jpabasic.pinnolbe.domain.study.Chapter;
 import jpabasic.pinnolbe.domain.study.Study;
 import jpabasic.pinnolbe.dto.analyze.AttendanceDto;
@@ -406,27 +408,43 @@ public class StudyLogService {
     }
 
     //현재 학습 중인 단원 + 레벨 제공
-    public NowStudyingLevelDto getNowStudyingLevel(User user,String sessionLogId){
+    public NowStudyingLevelDto getNowStudyingLevel(User user) {
 
-        List<StudySessionLog> list=studySessionLogRepository.findByUserId(sessionLogId);
-        StudySessionLog latestLog=list.stream()
-                .max(Comparator.comparing(StudySessionLog::getCreatedAt))//createdAt 기준으로 가장 최신
-                .orElseThrow(()->new CustomException(ErrorCode.STUDY_SESSION_LOG_NOT_FOUND)); //현재 진행 중인 레벨 없음
+        //현재 진행 중인 레벨이 user 필드에 studySessionLogId로 저장되어 있는 경우
+        if (user.getStudySessionLogId() != null) {
+            StudySessionLog log = studySessionLogRepository.findById(user.getStudySessionLogId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.STUDY_SESSION_ID_NOT_FOUND));
+            return toDto(log, 0);
+        }
 
-//        String studySessionLogId=user.getStudySessionLogId();
-//        StudySessionLog latestLog=studySessionLogRepository.findById(studySessionLogId).orElse(null);
+        List<StudySessionLog> list = studySessionLogRepository.findByUserId(user.getId());
+        StudySessionLog latestLog = list.stream()
+                .max(Comparator.comparing(StudySessionLog::getCreatedAt))
+                .orElseThrow(() -> new CustomException(ErrorCode.STUDY_SESSION_LOG_NOT_FOUND));
 
-        String chapterId=latestLog.getChapterId();
-        int level=latestLog.getLevel();
+        return latestLog.getStatus() == Status.COMPLETED
+                ? toDto(latestLog, 1)
+                : toDto(latestLog, 0);
 
-        Chapter chapter=chapterRepository.findById(chapterId).orElse(null);
-        String chapterTitle=chapter.getChapterTitle();
-
-        NowStudyingLevelDto result=new NowStudyingLevelDto(chapterTitle,level);
-        return result;
     }
 
-
+    private NowStudyingLevelDto toDto(StudySessionLog log, int levelOffset) {
+        Chapter chapter=chapterRepository.findById(log.getChapterId())
+                .orElseThrow(() -> new CustomException(ErrorCode.CHAPTER_NOT_FOUND));
+        ObjectId objectId=new ObjectId(log.getBookId());
+        Book book=bookRepository.findById(objectId)
+                .orElseThrow(()->new IllegalArgumentException("해당 책이 없어요."));
+        String bookTitle=book.getTitle();
+        int bookLevel=book.getBookLevel();
+        int targetLevel=log.getLevel()+levelOffset;
+        return new NowStudyingLevelDto(
+                bookLevel,
+                bookTitle,
+                log.getChapterId(),
+                chapter.getChapterTitle(),
+                targetLevel
+        );
+    }
 
 
 }

--- a/src/main/java/jpabasic/pinnolbe/service/study/StudyService.java
+++ b/src/main/java/jpabasic/pinnolbe/service/study/StudyService.java
@@ -360,6 +360,7 @@ public class StudyService {
     public ChapterListResponseDto getChapterList(User user, String bookId,int page){
         String currentChapterId;
         StudySessionLog log;
+        int currentLevel;
 
         //해당 교재의 모든 chapter List
         Slice<ChapterListResponseDto.ChapterResponseDto> chapters=getChaptersByBook(bookId,page,5);
@@ -369,18 +370,21 @@ public class StudyService {
         if (sessionLogId == null) {
             System.out.println("첫 학습이어서 첫번째 챕터로 자동 설정");
             currentChapterId = "682829708c776a1ffa92fd50"; // 첫 교재,첫 챕터 하드코딩
+            currentLevel = 1;
         } else {
             Optional<StudySessionLog> optLog = studySessionLogRepository.findById(sessionLogId);
             if (optLog.isPresent()) {
                 log = optLog.get();
                 System.out.println("currentChapterId 가져오기");
                 currentChapterId = log.getChapterId();
+                currentLevel = log.getLevel();
             } else {
                 currentChapterId = "682829708c776a1ffa92fd50"; // fallback
+                currentLevel = 1;
             }
         }
         //dto로 변환
-        ChapterListResponseDto result=new ChapterListResponseDto(sessionLogId,currentChapterId,chapters);
+        ChapterListResponseDto result=new ChapterListResponseDto(sessionLogId,currentChapterId,currentLevel,chapters);
         return result;
     }
 

--- a/src/main/java/jpabasic/pinnolbe/service/study/StudySessionService.java
+++ b/src/main/java/jpabasic/pinnolbe/service/study/StudySessionService.java
@@ -12,6 +12,7 @@ import jpabasic.pinnolbe.global.ErrorCode;
 import jpabasic.pinnolbe.global.exception.user.CustomException;
 import jpabasic.pinnolbe.repository.UserRepository;
 import jpabasic.pinnolbe.repository.analyze.StudySessionLogRepository;
+import jpabasic.pinnolbe.repository.study.BookRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
@@ -38,10 +39,12 @@ public class StudySessionService {
     private final ObjectMapper objectMapper;
     @Autowired
     private StudyLogService studyLogService;
+    @Autowired
+    private BookRepository bookRepository;
 
     /** 학습 시작 시 Redis에 세션 생성 */
     @Transactional
-    public String startLevel(User user, int level, String chapterId) {
+    public String startLevel(User user, int level, String chapterId,String bookId) {
         System.out.println("📘 [startLevel] 호출됨: userId=" + user.getId() + ", level=" + level + ", chapterId=" + chapterId);
 
         String userId = user.getId();
@@ -52,7 +55,8 @@ public class StudySessionService {
         System.out.println("✅ [startLevel] StudySession 객체 생성 완료");
 
         // StudySessionLog 확인 또는 생성
-        String studySessionLogId = findStudySessionLog(userId, chapterId, level);
+        String studySessionLogId = findStudySessionLog(userId, chapterId, bookId, level);
+
         user.setStudySessionLogId(studySessionLogId);
         userRepository.save(user);
         System.out.println("✅ [startLevel] User 문서 업데이트 완료, studySessionLogId=" + studySessionLogId);
@@ -69,14 +73,20 @@ public class StudySessionService {
     }
 
     /** StudySessionLog 찾기/생성 */
-    private String findStudySessionLog(String userId, String chapterId, int level) {
+    private String findStudySessionLog(String userId, String chapterId, String bookId,int level) {
         System.out.println("🔍 [findStudySessionLog] 실행 중...");
-        Optional<StudySessionLog> existingLogOpt = studySessionLogRepository.findByUserIdAndChapterIdAndLevel(userId, chapterId, level);
+        Optional<StudySessionLog> existingLogOpt =
+                studySessionLogRepository.findByUserIdAndChapterIdAndLevel(userId, chapterId, level);
+        System.out.println("existingLogOpt="+existingLogOpt.orElse(null));
         if (existingLogOpt.isPresent()) {
             System.out.println("✅ 기존 StudySessionLog 존재, ID=" + existingLogOpt.get().getId());
-            return existingLogOpt.get().getId();
+            StudySessionLog existing=existingLogOpt.get();
+            //기존에 db에 저장되어 있던 StudySessionLog를 ACTIVE 상태로 변환
+            existing.setStatus(Status.ACTIVE);
+            studySessionLogRepository.save(existing);
+            return existing.getId();
         } else {
-            StudySessionLog log = new StudySessionLog(userId, chapterId, level);
+            StudySessionLog log = new StudySessionLog(userId, chapterId, bookId,level);
             String id = studySessionLogRepository.save(log).getId();
             System.out.println("🆕 새로운 StudySessionLog 생성됨, ID=" + id);
             return id;
@@ -97,7 +107,7 @@ public class StudySessionService {
 
         if (session == null) {
             System.out.println("⚠️ Redis 세션이 존재하지 않아 새로 생성함");
-            startLevel(user, summary.getLevel(), summary.getChapterId());
+            startLevel(user, summary.getLevel(), summary.getChapterId(),summary.getBookId());
             throw new CustomException(ErrorCode.SESSION_NOT_FOUND);
         }
 
@@ -138,19 +148,47 @@ public class StudySessionService {
         // COMPLETE
         if (summary.getStatus() == Status.COMPLETED) {
             System.out.println("🏁 [COMPLETE] 감지 - DB 저장 로직 실행");
+            session.setStatus(Status.COMPLETED);
+            //학습한 시간 + 시간대 설정
+            updateTimeZone(session);
+
             StudySessionLogResponseDto dto=saveToDatabase(session); //studySessionLog에 저장
             System.out.println("✔️ dto: "+ dto);
+
+            if(session.getLevel()<=5){
+                //다음 레벨에 대한 StudySessionLog 저장해야
+                StudySessionLog newSession=new StudySessionLog(session.getUserId(), session.getChapterId(), session.getBookId(),session.getLevel()+1);
+                StudySessionLog saved=studySessionLogRepository.save(newSession);
+                user.setStudySessionLogId(saved.getId());
+                userRepository.save(user);
+            }else{
+                //레벨 6일 경우, sessionLog null 처리 후, finishChapter에서 다음 chapter로 넘어가도록 설정
+                user.setStudySessionLogId(null);
+                userRepository.save(user);
+            }
+
             //redis 세션 삭제
             boolean deleted=redisTemplate.delete(key);
-            //user필드 studySessionLogId 삭제
-            user.setStudySessionLogId(null);
-            userRepository.save(user);
             System.out.println("🧹 Redis 세션 삭제 완료"+deleted);
 
             //레벨 학습완료 후, 해당 레벨 학습 시간 weeklyAnalysis에 저장
             WeeklyAnalysis weeklyAnalysis=studyLogService.saveUntilStudyTime(dto);
             String weeklyId= weeklyAnalysis.getId();
             dto.setWeeklyAnalysisId(weeklyId);
+
+            return dto;
+        }
+
+        //EXIT (유저가 학습하기 창에서 나감)
+        if(summary.getStatus()==Status.EXIT){
+            System.out.println("🚫 [EXIT] 유저가 학습하기 창에서 나감 ");
+            session.setStatus(Status.EXIT);
+            StudySessionLogResponseDto dto=saveToDatabase(session); //studySessionLog에 저장
+            //redis 삭제
+            boolean deleted=redisTemplate.delete(key);
+            //user 필드에 현재 세션 진도 저장
+            user.setStudySessionLogId(dto.getId());
+            userRepository.save(user);
 
             return dto;
         }


### PR DESCRIPTION
### 🙌 작업 내용
- "`특정 레벨 공부시작(/api/session-start-level)`" api request parameter 수정 => bookId를 request parameter 추가 
- "`학습 상태 저장(/api/session/update)`" 수정 => bookId를 request body에 추가
- 유저가 학습하기 창을 나갔을 때 EXIT로 status를 준다 -> 세션 상의 status 변경 & DB에 저장 해서 현재 진도 상태 저장 -> 다음에 접속했을 때 이어서 학습할 수 있도록 함
- 학습분석: `현재 단원 레벨(/api/study-log/now-studying)` api 수정 => 리턴값 변경
<img width="1205" height="660" alt="image" src="https://github.com/user-attachments/assets/796e5d77-8c8a-4436-bc77-1e2ab755e324" />

- `학습하기: /api/study/chapter-select` API 수정 => 리턴값에 currentLevel 추
<img width="1206" height="827" alt="image" src="https://github.com/user-attachments/assets/17dada59-4128-4e62-a5ef-5bb4a4e7cbfa" />

