### PR TITLE
Hotfix: MongoDB reward 엔티티에 index 도입

### DIFF
--- a/src/main/java/jpabasic/pinnolbe/domain/reward/Reward.java
+++ b/src/main/java/jpabasic/pinnolbe/domain/reward/Reward.java
@@ -10,7 +10,10 @@ import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection="reward")
-@CompoundIndex(name="idx_userId_createdAt",def="{'userId':1,'createdAt':-1}")
+@CompoundIndex(
+        name="idx_userId_createdAt",
+        def="{'userId':1,'createdAt':-1}"
+)
 @AllArgsConstructor
 @NoArgsConstructor
 @Setter
@@ -19,6 +22,7 @@ public class Reward extends BaseEntity {
 
     @Id
     private String id;
+    //유저 기준으로 조회가 매우 많이 일어나므로 인덱스 필수
     private String userId;
     private Integer coin;
     private PointCategory category;

--- a/src/main/java/jpabasic/pinnolbe/domain/reward/Reward.java
+++ b/src/main/java/jpabasic/pinnolbe/domain/reward/Reward.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 @Document(collection="reward")
@@ -23,6 +24,7 @@ public class Reward extends BaseEntity {
     @Id
     private String id;
     //유저 기준으로 조회가 매우 많이 일어나므로 인덱스 필수
+    @Indexed
     private String userId;
     private Integer coin;
     private PointCategory category;


### PR DESCRIPTION
### 🙌 작업 내용
- (기존) reward 조회 기능 중 findAllByUserId로 조회한 후에 createdAt으로 정렬, 페이징 
- userId, createdAt 로 복합인덱스 적용하고, userId 기준으로 단일 인덱스 적용 -> 응답 속도 가속화
